### PR TITLE
Add video metadata

### DIFF
--- a/open-graph-protocol-tools.php
+++ b/open-graph-protocol-tools.php
@@ -140,6 +140,7 @@ function opengraphprotocoltools_embed_youtube($post_id) {
 	}
 	
 	if ($matches[1]) {
+		$data['og:image']      = 'http://img.youtube.com/vi/' . $matches[1] . '/0.jpg';
 		$data['og:video']      = 'http://www.youtube.com/embed/'.$matches[1];
 		$data['og:video:type'] = 'text/html';
 	}


### PR DESCRIPTION
When a YouTube video is embedded in the post, a link will be added as `og:video`
