### PR TITLE
Disable JetPack's own Open Graph data

### DIFF
--- a/open-graph-protocol-tools.php
+++ b/open-graph-protocol-tools.php
@@ -360,6 +360,7 @@ function get_opengraphprotocoltools_like_code() {
 	return $out;
 }
 
+add_filter('jetpack_enable_open_graph', '__return_false');
 add_filter('user_contactmethods', 'opengraphprotocoltools_user_contactmethods');
 add_action('wp_head', 'opengraphprotocoltools_add_head');
 add_action('admin_menu', 'opengraphprotocoltools_plugin_menu');


### PR DESCRIPTION
This will prevent Automattic's JetPack plugin from adding Open Graph data to each page.
With out this, when both plugins are active, data is added twice.