### PR TITLE
Check if `twitter:creator` exists before checking value

### DIFF
--- a/open-graph-protocol-tools.php
+++ b/open-graph-protocol-tools.php
@@ -308,9 +308,9 @@ function get_opengraphprotocoltools_headers($meta_tags) {
 	$out = array();
 	$out[] = "\n<!-- BEGIN: Open Graph Protocol Tools: http://opengraphprotocol.org/ for more info -->";
 
-	if ( $meta_tags['twitter:site'] == '@' )
+	if ( in_array('twitter:site',$meta_tags) && $meta_tags['twitter:site'] == '@' )
 		$meta_tags['twitter:site'] = '';
-	if ( $meta_tags['twitter:creator'] == '@' )
+	if ( in_array('twitter:creator',$meta_tags) && $meta_tags['twitter:creator'] == '@' )
 		$meta_tags['twitter:creator'] = '';
 
 	foreach ($meta_tags as $property => $content) {


### PR DESCRIPTION
This fixes a Warning that PHP was giving me when `WP_DEBUG` is enabled
